### PR TITLE
Add apex only parameter to getTypeIdentifiers

### DIFF
--- a/src/main/scala/com/nawforce/apexlink/api/Org.scala
+++ b/src/main/scala/com/nawforce/apexlink/api/Org.scala
@@ -86,7 +86,7 @@ trait Org {
     *
     * Returns an array which may be empty.
     */
-  def getTypeIdentifiers: Array[TypeIdentifier]
+  def getTypeIdentifiers(apexOnly: Boolean): Array[TypeIdentifier]
 
   /** Get Apex type dependency map for all types in the Org.
     *

--- a/src/main/scala/com/nawforce/apexlink/api/Package.scala
+++ b/src/main/scala/com/nawforce/apexlink/api/Package.scala
@@ -52,7 +52,7 @@ trait Package {
     *
     * Returns an array which may be empty.
     */
-  def getTypeIdentifiers: Array[TypeIdentifier]
+  def getTypeIdentifiers(apexOnly: Boolean): Array[TypeIdentifier]
 
   /** Get a TypeIdentifier for a TypeName resolved against this package.
     *

--- a/src/main/scala/com/nawforce/apexlink/org/Module.scala
+++ b/src/main/scala/com/nawforce/apexlink/org/Module.scala
@@ -100,11 +100,11 @@ class Module(val pkg: PackageImpl, val index: DocumentIndex, dependents: Seq[Mod
 
   /** Iterate metadata defined types, this will include referenced platform SObjects irrespective of if they have been
     * extended or not which is perhaps not quite accurate to the method name. */
-  def getMetadataDefinedTypeIdentifiers: Iterable[TypeIdentifier] = {
+  def getMetadataDefinedTypeIdentifiers(apexOnly: Boolean): Iterable[TypeIdentifier] = {
     types.values
       .collect {
-        case x: ApexDeclaration    => x
-        case x: SObjectDeclaration => x
+        case x: ApexDeclaration                 => x
+        case x: SObjectDeclaration if !apexOnly => x
       }
       .map(td => TypeIdentifier(namespace, td.typeName))
   }

--- a/src/main/scala/com/nawforce/apexlink/org/OrgImpl.scala
+++ b/src/main/scala/com/nawforce/apexlink/org/OrgImpl.scala
@@ -194,9 +194,9 @@ class OrgImpl(initWorkspace: Option[Workspace]) extends Org {
   }
 
   /** Get a array of type identifiers available across all packages. */
-  def getTypeIdentifiers: Array[TypeIdentifier] = {
+  def getTypeIdentifiers(apexOnly: Boolean): Array[TypeIdentifier] = {
     OrgImpl.current.withValue(this) {
-      packages.foldLeft(Array[TypeIdentifier]())((acc, pkg) => acc ++ pkg.getTypeIdentifiers)
+      packages.foldLeft(Array[TypeIdentifier]())((acc, pkg) => acc ++ pkg.getTypeIdentifiers(apexOnly))
     }
   }
 

--- a/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
+++ b/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
@@ -168,10 +168,13 @@ trait PackageAPI extends Package {
   }
 
   /** Get a array of type identifiers from this packages modules. */
-  override def getTypeIdentifiers: Array[TypeIdentifier] = {
+  override def getTypeIdentifiers(apexOnly: Boolean): Array[TypeIdentifier] = {
     modules
-      .foldLeft(Set[TypeIdentifier]())((acc, module) => acc ++ module.getMetadataDefinedTypeIdentifiers)
-      .toArray
+      .foldLeft(Set[TypeIdentifier]())((acc, module) =>
+        acc ++ module.getMetadataDefinedTypeIdentifiers.filter(id =>
+          !apexOnly || TypeResolver(id.typeName, module).toOption.exists(
+            _.isInstanceOf[ApexDeclaration])))
+          .toArray
   }
 
   /** Flush all types to the passed cache */

--- a/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
+++ b/src/main/scala/com/nawforce/apexlink/org/PackageAPI.scala
@@ -170,11 +170,8 @@ trait PackageAPI extends Package {
   /** Get a array of type identifiers from this packages modules. */
   override def getTypeIdentifiers(apexOnly: Boolean): Array[TypeIdentifier] = {
     modules
-      .foldLeft(Set[TypeIdentifier]())((acc, module) =>
-        acc ++ module.getMetadataDefinedTypeIdentifiers.filter(id =>
-          !apexOnly || TypeResolver(id.typeName, module).toOption.exists(
-            _.isInstanceOf[ApexDeclaration])))
-          .toArray
+      .foldLeft(Set[TypeIdentifier]())((acc, module) => acc ++ module.getMetadataDefinedTypeIdentifiers(apexOnly))
+      .toArray
   }
 
   /** Flush all types to the passed cache */

--- a/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
+++ b/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
@@ -103,7 +103,7 @@ trait OrgAPI {
   def refresh(path: String): Future[Unit]
 
   @api.JSONRPCMethod(name = "getTypeIdentifiers")
-  def typeIdentifiers(): Future[GetTypeIdentifiersResult]
+  def typeIdentifiers(apexOnly: Boolean): Future[GetTypeIdentifiersResult]
 
   @api.JSONRPCMethod(name = "dependencyGraph")
   def dependencyGraph(identifier: IdentifierRequest, depth: Int): Future[DependencyGraph]

--- a/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
+++ b/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
@@ -105,19 +105,19 @@ object GetIssues {
   }
 }
 
-case class TypeIdentifiers(promise: Promise[GetTypeIdentifiersResult]) extends APIRequest {
+case class TypeIdentifiers(promise: Promise[GetTypeIdentifiersResult], apexOnly: Boolean) extends APIRequest {
   override def process(queue: OrgQueue): Unit = {
     val orgImpl = queue.org.asInstanceOf[OrgImpl]
     OrgImpl.current.withValue(orgImpl) {
-      promise.success(GetTypeIdentifiersResult(orgImpl.getTypeIdentifiers))
+      promise.success(GetTypeIdentifiersResult(orgImpl.getTypeIdentifiers(apexOnly)))
     }
   }
 }
 
 object TypeIdentifiers {
-  def apply(queue: OrgQueue): Future[GetTypeIdentifiersResult] = {
+  def apply(queue: OrgQueue, apexOnly: Boolean): Future[GetTypeIdentifiersResult] = {
     val promise = Promise[GetTypeIdentifiersResult]()
-    queue.add(new TypeIdentifiers(promise))
+    queue.add(new TypeIdentifiers(promise, apexOnly))
     promise.future
   }
 }
@@ -215,8 +215,8 @@ class OrgAPIImpl(quiet: Boolean) extends OrgAPI {
     Future(OrgQueue.instance().refresh(path))
   }
 
-  override def typeIdentifiers(): Future[GetTypeIdentifiersResult] = {
-    TypeIdentifiers(OrgQueue.instance())
+  override def typeIdentifiers(apexOnly: Boolean): Future[GetTypeIdentifiersResult] = {
+    TypeIdentifiers(OrgQueue.instance(), apexOnly)
   }
 
   override def dependencyGraph(identifier: IdentifierRequest, depth: Int): Future[DependencyGraph] = {

--- a/src/test/scala/com/nawforce/apexlink/pkg/PackageAPITest.scala
+++ b/src/test/scala/com/nawforce/apexlink/pkg/PackageAPITest.scala
@@ -852,7 +852,19 @@ class PackageAPITest extends AnyFunSuite with TestHelper {
       assert(!org.issues.hasErrorsOrWarnings)
 
       assert(
-        org.getTypeIdentifiers.map(_.toString).toSet == Set[String]("__sfdc_trigger/Foo", "Schema.Account", "Dummy"))
+        org.getTypeIdentifiers(false).map(_.toString).toSet == Set[String]("__sfdc_trigger/Foo", "Schema.Account", "Dummy"))
+    }
+  }
+
+  test("typeIdentifiers - apex only") {
+    FileSystemHelper.run(
+      Map("classes/Dummy.cls" -> "public class Dummy {}",
+        "triggers/Foo.trigger" -> "trigger Foo on Account (before insert) {}")) { root: PathLike =>
+      val org = createOrg(root)
+      assert(!org.issues.hasErrorsOrWarnings)
+
+      assert(
+        org.getTypeIdentifiers(true).map(_.toString).toSet == Set[String]("__sfdc_trigger/Foo", "Dummy"))
     }
   }
 
@@ -870,7 +882,7 @@ class PackageAPITest extends AnyFunSuite with TestHelper {
       assert(!org.issues.hasErrorsOrWarnings)
 
       assert(
-        org.getTypeIdentifiers.map(_.toString).toSet == Set[String]("__sfdc_trigger/test/Foo [test]",
+        org.getTypeIdentifiers(false).map(_.toString).toSet == Set[String]("__sfdc_trigger/test/Foo [test]",
                                                                     "Schema.Account [test]",
                                                                     "Dummy (test)"))
     }


### PR DESCRIPTION
I've added an apexOnly flag to the getTypeIdentifiers method. This breaks the API, I wasn't sure if the original no parameter method should be maintained.

