### PR TITLE
Reset the shadows list before determining the method map

### DIFF
--- a/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
+++ b/src/main/scala/com/nawforce/apexlink/cst/MethodMap.scala
@@ -101,6 +101,11 @@ object MethodMap {
     val errors = mutable.Buffer[Issue]()
     val localMethodsByType = newMethods.groupBy(_.isStatic)
 
+    localMethodsByType.get(false).foreach(methods => methods.foreach( method => method match {
+      case am: ApexMethodLike => am.resetShadows()
+      case _ =>
+    }))
+
     // Add instance methods first with validation checks
     val isTest = td.outermostTypeDeclaration.modifiers.contains(ISTEST_ANNOTATION)
     val isComplete = td.isComplete

--- a/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
+++ b/src/main/scala/com/nawforce/apexlink/types/apex/ApexDeclaration.scala
@@ -62,6 +62,10 @@ trait ApexMethodLike extends ApexVisibleMethodLike with IdLocatable {
   // Populated by type MethodMap construction
   private var shadows: List[MethodDeclaration] = Nil
 
+  def resetShadows(): Unit = {
+    shadows = Nil
+  }
+
   def addShadow(method: MethodDeclaration): Unit = {
     if (method ne this) {
       shadows = method :: shadows


### PR DESCRIPTION
The shadow list is only appended to, so different versions of the same method are appended to the list. Also methods are not removed. 

This causes errors when determining the used/unused status of a method.