### PR TITLE
Granular transitive dependency count control

### DIFF
--- a/src/main/scala/com/nawforce/apexlink/api/Org.scala
+++ b/src/main/scala/com/nawforce/apexlink/api/Org.scala
@@ -108,7 +108,7 @@ trait Org {
     * Depth should be a positive integer that indicates how far to search from the starting node for the passed
     * TypeIdentifier. The root node of the search is always returned if it can be found. Depths > 0 will include
     * additional nodes. */
-  def getDependencyGraph(identifier: Array[TypeIdentifier], depth: Integer, apexOnly: Boolean): DependencyGraph
+  def getDependencyGraph(identifier: Array[TypeIdentifier], depth: Integer, apexOnly: Boolean, ignoring: Array[TypeIdentifier]): DependencyGraph
 
   /** Locate a type definition given source file position of the type name to search for.
     *

--- a/src/main/scala/com/nawforce/apexlink/deps/DownWalker.scala
+++ b/src/main/scala/com/nawforce/apexlink/deps/DownWalker.scala
@@ -47,7 +47,7 @@ class DownWalker(org: Org, apexOnly: Boolean) {
     val collectedNodes = new ArrayBuffer[NodeData]()
     val collectedIds = new mutable.HashSet[TypeIdentifier]()
 
-    val roots = identifiers.flatMap(i => createNode(i,ignoring))
+    val roots = identifiers.filterNot(i=>ignoring.contains(i)).flatMap(i => createNode(i,ignoring))
     collectedNodes.addAll(roots)
     collectedIds.addAll(identifiers)
 
@@ -63,7 +63,7 @@ class DownWalker(org: Org, apexOnly: Boolean) {
                        depth: Int,
                        ignoring:Array[TypeIdentifier]): Unit = {
     if (depth == 0) return
-    (node.extending ++ node.implementing ++ node.using).foreach(id => {
+    (node.extending ++ node.implementing ++ node.using).filterNot(n=>ignoring.contains(n)).foreach(id => {
       if (!collected.contains(id)) {
         collected.add(id)
         createNode(id, ignoring).foreach(node => {

--- a/src/main/scala/com/nawforce/apexlink/deps/DownWalker.scala
+++ b/src/main/scala/com/nawforce/apexlink/deps/DownWalker.scala
@@ -45,11 +45,13 @@ class DownWalker(org: Org, apexOnly: Boolean) {
    */
   def walk(identifiers: Array[TypeIdentifier], depth: Int, ignoring:Array[TypeIdentifier]): Array[NodeData] = {
     val collectedNodes = new ArrayBuffer[NodeData]()
-    val collectedIds = new mutable.HashSet[TypeIdentifier]()
+    val collectedIds   = new mutable.HashMap[TypeIdentifier, Int]()
 
-    val roots = identifiers.filterNot(i=>ignoring.contains(i)).flatMap(i => createNode(i,ignoring))
+    val roots = identifiers
+      .filterNot(i => ignoring.contains(i))
+      .flatMap(i => createNode(i,ignoring))
     collectedNodes.addAll(roots)
-    collectedIds.addAll(identifiers)
+    identifiers.foreach(i => collectedIds.addOne(i, 0))
 
     roots.foreach(root => {
       walkNode(root, collectedNodes, collectedIds, depth, ignoring)
@@ -59,29 +61,39 @@ class DownWalker(org: Org, apexOnly: Boolean) {
 
   private def walkNode(node: NodeData,
                        collector: ArrayBuffer[NodeData],
-                       collected: mutable.Set[TypeIdentifier],
+                       collected: mutable.Map[TypeIdentifier,Int],
                        depth: Int,
                        ignoring:Array[TypeIdentifier]): Unit = {
     if (depth == 0) return
-    (node.extending ++ node.implementing ++ node.using).filterNot(n=>ignoring.contains(n)).foreach(id => {
-      if (!collected.contains(id)) {
-        collected.add(id)
-        createNode(id, ignoring).foreach(node => {
-          collector.append(node)
-          walkNode(node, collector, collected, depth - 1, ignoring)
-        })
-      }
-    })
+    (node.extending ++ node.implementing ++ node.using)
+      .filterNot(n => ignoring.contains(n))
+      .foreach(id => {
+        if (!collected.contains(id) || collected(id) <= depth) {
+          collected.addOne(id, depth)
+          createNode(id, ignoring).foreach(node => {
+            findAndReplace(collector, node)
+            walkNode(node, collector, collected, depth - 1, ignoring)
+          })
+        }
+      })
   }
 
-  private def createNode(id: TypeIdentifier, ignoring:Array[TypeIdentifier]): Option[NodeData] = {
+  private def findAndReplace(collector: ArrayBuffer[NodeData], nodeData: NodeData): Unit = {
+    val index = collector.indexWhere(n => n.id.equals(nodeData.id))
+    if (index >= 0)
+      collector(index) = nodeData
+    else
+      collector.addOne(nodeData)
+  }
+
+  private def createNode(id: TypeIdentifier, ignoring: Array[TypeIdentifier]): Option[NodeData] = {
     org
       .asInstanceOf[OrgImpl]
       .findTypeIdentifier(id)
       .filter(td => !apexOnly || td.isInstanceOf[ApexDeclaration])
       .collect { case td: DependencyHolder => td }
       .map(td => {
-        val pkg = td.moduleDeclaration.map(_.pkg)
+        val pkg    = td.moduleDeclaration.map(_.pkg)
         val typeId = pkg.map(pkg => TypeIdentifier(pkg.namespace, td.typeName))
 
         val inherits =
@@ -91,10 +103,11 @@ class DownWalker(org: Org, apexOnly: Boolean) {
               case _                        => None
             })
             .filterNot(d => typeId.contains(d._2))
+            .filterNot(d => ignoring.contains(d._2))
             .toSet
-        val extending = inherits.filter(id => id._1 == CLASS_NATURE).map(_._2)
+        val extending    = inherits.filter(id => id._1 == CLASS_NATURE).map(_._2)
         val implementing = inherits.filter(id => id._1 == INTERFACE_NATURE).map(_._2)
-        val output = extending ++ implementing
+        val output       = extending ++ implementing
 
         val all =
           pkg
@@ -102,9 +115,17 @@ class DownWalker(org: Org, apexOnly: Boolean) {
               Option(pkg.getDependencies(id, outerInheritanceOnly = false, apexOnly))
             })
             .getOrElse(Array[TypeIdentifier]())
-        val uses = all.filterNot(output.contains).filterNot(id => typeId.contains(id))
-
-        NodeData(id, td.nature.value, transitiveCollector.count(id, ignoring), extending.toArray, implementing.toArray, uses)
+        val uses = all.filterNot(output.contains)
+                      .filterNot(id => typeId.contains(id))
+                      .filterNot(id => ignoring.contains(id))
+        NodeData(
+          id,
+          td.nature.value,
+          transitiveCollector.count(id, ignoring),
+          extending.toArray,
+          implementing.toArray,
+          uses
+        )
       })
   }
 }

--- a/src/main/scala/com/nawforce/apexlink/deps/TransitiveCollector.scala
+++ b/src/main/scala/com/nawforce/apexlink/deps/TransitiveCollector.scala
@@ -24,18 +24,18 @@ class TransitiveCollector(org: Org, apexOnly: Boolean) {
   private val packagesByNamespace =
     org.getPackages().map(pkg => (Name(pkg.getNamespaces(false).head), pkg)).toMap
 
-  def count(id: TypeIdentifier): Int = {
-    transitives(id).length
+  def count(id: TypeIdentifier, ignoring: Array[TypeIdentifier] ): Int = {
+    transitives(id,ignoring).length
   }
 
-  def transitives(id: TypeIdentifier): Array[TypeIdentifier] = {
+  def transitives(id: TypeIdentifier, ignoring: Array[TypeIdentifier] = Array()): Array[TypeIdentifier] = {
     val pkg = packagesByNamespace.get(id.namespace.getOrElse(Names.Empty))
 
     val depsSeen = mutable.Set[TypeIdentifier]()
     depsSeen.add(id)
+    ignoring.foreach(i => depsSeen.add(i))
     val deps = mutable.ArrayBuffer[TypeIdentifier]()
     deps.append(id)
-
     var current = 0
     while (current < deps.size) {
       pkg

--- a/src/main/scala/com/nawforce/apexlink/org/OrgImpl.scala
+++ b/src/main/scala/com/nawforce/apexlink/org/OrgImpl.scala
@@ -233,15 +233,14 @@ class OrgImpl(initWorkspace: Option[Workspace]) extends Org {
       })
   }
 
-  def getDependencyGraph(identifiers: Array[TypeIdentifier], depth: Integer, apexOnly: Boolean): DependencyGraph = {
+  def getDependencyGraph(identifiers: Array[TypeIdentifier], depth: Integer, apexOnly: Boolean, ignoring: Array[TypeIdentifier]): DependencyGraph = {
     OrgImpl.current.withValue(this) {
       val depWalker = new DownWalker(this, apexOnly)
       val nodeData = depWalker
-        .walk(identifiers, depth)
+        .walk(identifiers, depth, ignoring)
         .map(n => {
           DependencyNode(n.id, nodeFileSize(n.id), n.nature, n.transitiveCount, n.extending, n.implementing, n.using)
         })
-
       val nodeIndex = nodeData.map(_.identifier).zipWithIndex.toMap
 
       val linkData = new ArrayBuffer[DependencyLink]()

--- a/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
+++ b/src/main/scala/com/nawforce/apexlink/rpc/OrgAPI.scala
@@ -159,7 +159,7 @@ trait OrgAPI {
   def typeIdentifiers(apexOnly: Boolean): Future[GetTypeIdentifiersResult]
 
   @api.JSONRPCMethod(name = "dependencyGraph")
-  def dependencyGraph(identifiers: IdentifiersRequest, depth: Int, apexOnly: Boolean): Future[DependencyGraph]
+  def dependencyGraph(identifiers: IdentifiersRequest, depth: Int, apexOnly: Boolean, ignoring: IdentifiersRequest): Future[DependencyGraph]
 
   @api.JSONRPCMethod(name = "identifierLocation")
   def identifierLocation(identifier: IdentifierRequest): Future[IdentifierLocationResult]

--- a/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
+++ b/src/main/scala/com/nawforce/apexlink/rpc/OrgAPIImpl.scala
@@ -126,17 +126,18 @@ object TypeIdentifiers {
 case class DependencyGraphRequest(promise: Promise[DependencyGraph],
                                   identifiers: Array[TypeIdentifier],
                                   depth: Int,
-                                  apexOnly: Boolean)
+                                  apexOnly: Boolean,
+                                  ignoring: Array[TypeIdentifier])
     extends APIRequest {
   override def process(queue: OrgQueue): Unit = {
-    promise.success(queue.org.getDependencyGraph(identifiers, depth, apexOnly))
+    promise.success(queue.org.getDependencyGraph(identifiers, depth, apexOnly, ignoring))
   }
 }
 
 object DependencyGraphRequest {
-  def apply(queue: OrgQueue, identifiers: Array[TypeIdentifier], depth: Int, apexOnly: Boolean): Future[DependencyGraph] = {
+  def apply(queue: OrgQueue, identifiers: Array[TypeIdentifier], depth: Int, apexOnly: Boolean,  ignoring: Array[TypeIdentifier]): Future[DependencyGraph] = {
     val promise = Promise[DependencyGraph]()
-    queue.add(new DependencyGraphRequest(promise, identifiers, depth, apexOnly))
+    queue.add(new DependencyGraphRequest(promise, identifiers, depth, apexOnly, ignoring))
     promise.future
   }
 }
@@ -325,8 +326,9 @@ class OrgAPIImpl(quiet: Boolean) extends OrgAPI {
 
   override def dependencyGraph(identifiers: IdentifiersRequest,
                                depth: Int,
-                               apexOnly: Boolean): Future[DependencyGraph] = {
-    DependencyGraphRequest(OrgQueue.instance(), identifiers.identifiers, depth, apexOnly)
+                               apexOnly: Boolean,
+                               ignoring: IdentifiersRequest): Future[DependencyGraph] = {
+    DependencyGraphRequest(OrgQueue.instance(), identifiers.identifiers, depth, apexOnly, ignoring.identifiers)
   }
 
   override def identifierLocation(request: IdentifierRequest): Future[IdentifierLocationResult] = {

--- a/src/test/scala/com/nawforce/apexlink/pkg/DependencyGraphTest.scala
+++ b/src/test/scala/com/nawforce/apexlink/pkg/DependencyGraphTest.scala
@@ -1,0 +1,190 @@
+package com.nawforce.apexlink.pkg
+
+import com.nawforce.apexlink.rpc.{DependencyLink, DependencyNode}
+import com.nawforce.apexlink.{FileSystemHelper, TestHelper}
+import com.nawforce.pkgforce.names.{Name, TypeIdentifier, TypeName}
+import com.nawforce.pkgforce.path.PathLike
+import org.scalatest.funsuite.AnyFunSuite
+
+class DependencyGraphTest extends AnyFunSuite with TestHelper {
+
+  test("Correct dependencies returned at depth 1") {
+    FileSystemHelper.run(
+      Map(
+        "A.cls" -> "public class A extends B { C c;}",
+        "B.cls" -> "public class B {C c;}",
+        "C.cls" -> "public class C {D d;}",
+        "D.cls" -> "public class D {}"
+      )
+    ) { root: PathLike =>
+      val org = createOrg(root)
+      val result = org.getDependencyGraph(
+        Array(TypeIdentifier(None, TypeName(Name("A")))),
+        1,
+        apexOnly = true,
+        Array()
+      )
+      assert(
+        result.nodeData sameElements Array(
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("A"))),
+            32,
+            "class",
+            3,
+            Array(TypeIdentifier(None, TypeName(Name("B")))),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("C"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("B"))),
+            21,
+            "class",
+            2,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("C"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("C"))),
+            21,
+            "class",
+            1,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("D"))))
+          )
+        )
+      )
+      assert(
+        result.linkData sameElements Array(
+          DependencyLink(0, 1, "extends"),
+          DependencyLink(0, 2, "uses"),
+          DependencyLink(1, 2, "uses")
+        )
+      )
+    }
+  }
+
+  test("Correct dependencies returned at depth 2") {
+    FileSystemHelper.run(
+      Map(
+        "A.cls" -> "public class A extends B { C c;}",
+        "B.cls" -> "public class B {C c;}",
+        "C.cls" -> "public class C {D d;}",
+        "D.cls" -> "public class D {}"
+      )
+    ) { root: PathLike =>
+      val org = createOrg(root)
+      val result = org.getDependencyGraph(
+        Array(TypeIdentifier(None, TypeName(Name("A")))),
+        2,
+        apexOnly = true,
+        Array()
+      )
+      assert(
+        result.nodeData sameElements Array(
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("A"))),
+            32,
+            "class",
+            3,
+            Array(TypeIdentifier(None, TypeName(Name("B")))),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("C"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("B"))),
+            21,
+            "class",
+            2,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("C"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("C"))),
+            21,
+            "class",
+            1,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("D"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("D"))),
+            17,
+            "class",
+            0,
+            Array(),
+            Array(),
+            Array()
+          )
+        )
+      )
+      assert(
+        result.linkData sameElements Array(
+          DependencyLink(0, 1, "extends"),
+          DependencyLink(0, 2, "uses"),
+          DependencyLink(1, 2, "uses"),
+          DependencyLink(2, 3, "uses")
+        )
+      )
+    }
+  }
+
+  test("Correct dependencies returned at depth 2 with ignored") {
+    FileSystemHelper.run(
+      Map(
+        "A.cls" -> "public class A extends B { C c;}",
+        "B.cls" -> "public class B {C c;}",
+        "C.cls" -> "public class C {D d;}",
+        "D.cls" -> "public class D {}"
+      )
+    ) { root: PathLike =>
+      val org = createOrg(root)
+      val result = org.getDependencyGraph(
+        Array(TypeIdentifier(None, TypeName(Name("A")))),
+        2,
+        apexOnly = true,
+        Array(TypeIdentifier(None, TypeName(Name("B"))))
+      )
+      assert(
+        result.nodeData sameElements Array(
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("A"))),
+            32,
+            "class",
+            2,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("C"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("C"))),
+            21,
+            "class",
+            1,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("D"))))
+          ),
+          DependencyNode(
+            TypeIdentifier(None, TypeName(Name("D"))),
+            17,
+            "class",
+            0,
+            Array(),
+            Array(),
+            Array()
+          )
+        )
+      )
+      assert(
+        result.linkData sameElements Array(
+          DependencyLink(0, 1, "uses"),
+          DependencyLink(1, 2, "uses")
+        )
+      )
+    }
+  }
+}

--- a/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
+++ b/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
@@ -198,16 +198,9 @@ class OrgAPITest extends AsyncFunSuite {
             0,
             Array(),
             Array(),
-            Array(TypeIdentifier(None, TypeName(Name("World"))))),
-          DependencyNode(TypeIdentifier(None, TypeName(Name("World"))),
-            71,
-            "class",
-            0,
-            Array(),
-            Array(),
-            Array()),
+            Array())
         ))
-      assert(graph.linkData sameElements Array(DependencyLink(0, 1, "uses")))
+      assert(graph.linkData.isEmpty)
     }
   }
 

--- a/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
+++ b/src/test/scala/com/nawforce/apexlink/rpc/OrgAPITest.scala
@@ -138,7 +138,7 @@ class OrgAPITest extends AsyncFunSuite {
       result <- orgAPI.open(workspace.toString)
       graph <- orgAPI.dependencyGraph(
         IdentifiersRequest(Array(TypeIdentifier(None, TypeName(Name("Hello"))))),
-        depth = 0, apexOnly = true)
+        depth = 0, apexOnly = true, IdentifiersRequest(Array()))
       _ <- orgAPI.reset()
     } yield {
       assert(result.error.isEmpty)
@@ -154,7 +154,7 @@ class OrgAPITest extends AsyncFunSuite {
       result <- orgAPI.open(workspace.toString)
       graph <- orgAPI.dependencyGraph(
         IdentifiersRequest(Array(TypeIdentifier(None, TypeName(Name("Hello"))))),
-        depth = 1, apexOnly = true)
+        depth = 1, apexOnly = true,  IdentifiersRequest(Array()))
       _ <- orgAPI.reset()
     } yield {
       assert(result.error.isEmpty)
@@ -179,6 +179,38 @@ class OrgAPITest extends AsyncFunSuite {
     }
   }
 
+  test("Get Dependency Graph (some depth) with ignored identifiers") {
+    val workspace = Path("samples/synthetic/mdapi-test")
+    val orgAPI = OrgAPI()
+    for {
+      result <- orgAPI.open(workspace.toString)
+      graph <- orgAPI.dependencyGraph(
+        IdentifiersRequest(Array(TypeIdentifier(None, TypeName(Name("Hello"))))),
+        depth = 1, apexOnly = true,  IdentifiersRequest(Array(TypeIdentifier(None, TypeName(Name("World"))))))
+      _ <- orgAPI.reset()
+    } yield {
+      assert(result.error.isEmpty)
+      assert(
+        graph.nodeData sameElements Array(
+          DependencyNode(TypeIdentifier(None, TypeName(Name("Hello"))),
+            85,
+            "class",
+            0,
+            Array(),
+            Array(),
+            Array(TypeIdentifier(None, TypeName(Name("World"))))),
+          DependencyNode(TypeIdentifier(None, TypeName(Name("World"))),
+            71,
+            "class",
+            0,
+            Array(),
+            Array(),
+            Array()),
+        ))
+      assert(graph.linkData sameElements Array(DependencyLink(0, 1, "uses")))
+    }
+  }
+
   test("Get Dependency Graph (bad identifier))") {
     val workspace = Path("samples/synthetic/mdapi-test")
     val orgAPI = OrgAPI()
@@ -186,7 +218,7 @@ class OrgAPITest extends AsyncFunSuite {
       result <- orgAPI.open(workspace.toString)
       graph <- orgAPI.dependencyGraph(
         IdentifiersRequest(Array(TypeIdentifier(None, TypeName(Name("Dummy"))))),
-        depth = 0, apexOnly = true)
+        depth = 0, apexOnly = true, IdentifiersRequest(Array()))
       _ <- orgAPI.reset()
     } yield {
       assert(result.error.isEmpty)


### PR DESCRIPTION
Adds extra parameter to dependencyGraph method to ignore identifiers when collecting transitive dependency count. 